### PR TITLE
Fix Image Overlap with Fixed-Position Header using Vanilla CSS

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -51,7 +51,7 @@ export default component$((props: ModalProps) => {
             <img
               src={props.image}
               alt="hero image"
-              class={image}
+              // class={image}
               width={480}
               height={480}
             />

--- a/src/components/infobox/InfoBox.tsx
+++ b/src/components/infobox/InfoBox.tsx
@@ -35,7 +35,7 @@ export default component$((props: ModalProps) => {
           <a href={props.linkToApp} target="_blank" rel="noreferrer">
             <img
               src={props.image}
-              style="filter: drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1)); border-radius: 1rem;"
+              style="border-radius: 1rem; box-shadow: 8px 8px 45px 0px rgba(66, 68, 90, 0.2);"
               width={700}
               height={400}
             />

--- a/src/components/navbar/NavbarHome.tsx
+++ b/src/components/navbar/NavbarHome.tsx
@@ -149,7 +149,6 @@ export default component$(() => {
                   href={item.link}
                   target="_blank"
                   rel="noreferrer"
-                  style="padding-right: 20px; padding-left: 20px;"
                 >
                   <img src={item.icon} width={20} height={20} />
                 </a>


### PR DESCRIPTION
In this PR, I've addressed the issue with images on the landing page overlapping the fixed-position header.

**Background:**
Previously, we mitigated this overlap by using the `z-index` property. However, in my opinion, this solution wasn't the most elegant. 

**Changes Made:**
- Fixed the overlapping issue using vanilla CSS.
- Identified that the use of CSS `filters` caused images to overlap the fixed-position header.
- Noted that images with `absolute` positioning also overlapped the fixed-position header.

The described issues have now been resolved, ensuring images correctly display behind the header.